### PR TITLE
add: PlugのコンポーネントにVRCFuryが存在しない場合エラーとなることを記載

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NDMF ParameterProviderに対応
 
 ### Changed
+- PlugのコンポーネントにVRCFuryが存在しない場合エラーとなることを記載
 
 ### Deprecated
 

--- a/ndmf_sps/Editor/CustomEditor/PlugEditor.cs
+++ b/ndmf_sps/Editor/CustomEditor/PlugEditor.cs
@@ -14,6 +14,7 @@ namespace com.meronmks.ndmfsps
             Plug plug = target as Plug;
             Localization.SelectLanguageGUI();
             CommonGUI.ShowCommonHelpBox();
+            EditorGUILayout.HelpBox(Localization.S("inspector.common.plugWarnMes"), MessageType.Warning);
             EditorGUILayout.Separator();
 
             var pAutomaticallyFindMesh = serializedObject.FindProperty(nameof(Plug.automaticallyFindMesh));

--- a/ndmf_sps/Editor/Localization/en-US.json
+++ b/ndmf_sps/Editor/Localization/en-US.json
@@ -2,6 +2,7 @@
   "Language": "English (United States)",
 
   "inspector.common.commonInfoMes": "For SPS to work properly, set the Pixel Lights setting in VRChat to High.\nIn VRChat settings, set Settings > Graphics > Advanced > Pixel Lights to High.",
+  "inspector.common.plugWarnMes": "To use Plug, VRCFury is required. If it does not exist, it will be built at build time with an error.",
   "inspector.common.enableDeformation": "Enable deformation",
   "inspector.common.enableDepthAnimations": "Enable depth actions",
   "inspector.common.depthActions": "Actions",

--- a/ndmf_sps/Editor/Localization/ja-JP.json
+++ b/ndmf_sps/Editor/Localization/ja-JP.json
@@ -2,6 +2,7 @@
   "Language": "日本語 (日本)",
 
   "inspector.common.commonInfoMes": "SPSを正しく動作させるにはVRChatの [ピクセルライト数] 設定が [高] に設定してください。\nVRChat設定の [設定] > [グラフィックス] > [詳細設定] > [ピクセルライト数] を [高] に設定してください。",
+  "inspector.common.plugWarnMes": "Plugを利用するにはVRCFuryが必要です。存在しない場合ビルド時にエラーとなります。",
   "inspector.common.enableDeformation": "変形を有効にする",
   "inspector.common.enableDepthAnimations": "位置によるアクションを有効にする",
   "inspector.common.depthActions": "アクション一覧",


### PR DESCRIPTION
#8 の対応
とりあえずなにも記載せずにビルドエラーとなるのはよくないのでコンポーネントに記載。