### PR TITLE
feat: SocketのReceiverでアニメーションする値(Mapped)をAAP演算で計算する

### DIFF
--- a/ndmf_sps/Editor/Processor/AapMath.cs
+++ b/ndmf_sps/Editor/Processor/AapMath.cs
@@ -18,6 +18,7 @@ namespace com.meronmks.ndmfsps
         private readonly HashSet<string> _registeredParams = new HashSet<string>();
         private readonly Dictionary<string, float> _paramDefaults = new Dictionary<string, float>();
         private readonly string _paramPrefix;
+        private readonly Dictionary<float, string> _cachedSpeeds = new Dictionary<float, string>();
         private bool _needsFrameTimeLayer;
 
         private const string AlwaysOneParam = "__ndmfsps_one";
@@ -325,9 +326,14 @@ namespace com.meronmks.ndmfsps
             if (smoothingSeconds <= 0) return targetParam;
             if (smoothingSeconds > 10) smoothingSeconds = 10;
 
-            var frameTime = GetOrCreateFrameTime();
-            var fractionPerSecond = CalculateFractionPerSecond(smoothingSeconds);
-            var speedParam = Multiply($"{name}/Speed", frameTime, fractionPerSecond);
+            // 同じsmoothingSecondsのSpeedパラメータをキャッシュして共有
+            if (!_cachedSpeeds.TryGetValue(smoothingSeconds, out var speedParam))
+            {
+                var frameTime = GetOrCreateFrameTime();
+                var fractionPerSecond = CalculateFractionPerSecond(smoothingSeconds);
+                speedParam = Multiply($"smoothingSpeed/{smoothingSeconds}", frameTime, fractionPerSecond);
+                _cachedSpeeds[smoothingSeconds] = speedParam;
+            }
 
             // 2パス: 加速度付きスムージング
             var pass1 = SmoothSinglePass($"{name}/Pass1", targetParam, speedParam);

--- a/ndmf_sps/Editor/Processor/AapMath.cs
+++ b/ndmf_sps/Editor/Processor/AapMath.cs
@@ -367,9 +367,9 @@ namespace com.meronmks.ndmfsps
             }
 
             // 2パス: 加速度付きスムージング
+            // Pass1は中間パラメータ、Pass2は呼び出し元が期待するnameに直接書き込む
             var pass1 = SmoothSinglePass($"{name}/Pass1", targetParam, speedParam);
-            var pass2 = SmoothSinglePass($"{name}/Pass2", pass1, speedParam);
-            return pass2;
+            return SmoothSinglePass(name, pass1, speedParam);
         }
 
         /// <summary>

--- a/ndmf_sps/Editor/Processor/AapMath.cs
+++ b/ndmf_sps/Editor/Processor/AapMath.cs
@@ -16,14 +16,17 @@ namespace com.meronmks.ndmfsps
         private readonly AnimatorController _controller;
         private readonly BlendTree _directTree;
         private readonly HashSet<string> _registeredParams = new HashSet<string>();
+        private readonly string _paramPrefix;
+        private bool _needsFrameTimeLayer;
 
         private const string AlwaysOneParam = "__ndmfsps_one";
 
         public BlendTree DirectTree => _directTree;
 
-        public AapMath(AnimatorController controller)
+        public AapMath(AnimatorController controller, string paramPrefix = "")
         {
             _controller = controller;
+            _paramPrefix = paramPrefix;
             _directTree = new BlendTree
             {
                 name = "DBT",
@@ -172,6 +175,191 @@ namespace com.meronmks.ndmfsps
         public Motion MakeConstSetter(string toParam, float value)
         {
             return MakeSetterClip(toParam, value);
+        }
+
+        /// <summary>
+        /// パラメータに定数を掛けたAAPを作成。output = param * constant
+        /// </summary>
+        public string Multiply(string name, string param, float constant)
+        {
+            EnsureParam(param);
+            var output = MakeAap(name);
+            AddDirect(param, MakeSetterClip(output, constant));
+            return output;
+        }
+
+        /// <summary>
+        /// パラメータの1フレーム遅延コピーを作成。
+        /// Direct BlendTreeは前フレームのパラメータ値を読むため、
+        /// copierを追加するだけで1フレーム遅延が得られる。
+        /// </summary>
+        public string Buffer(string fromParam, string toName = null)
+        {
+            EnsureParam(fromParam);
+            toName = toName ?? $"{fromParam}_buf";
+            var output = MakeAap(toName);
+            AddDirect(MakeCopier(fromParam, output));
+            return output;
+        }
+
+        /// <summary>
+        /// a - b を計算するAAPを作成
+        /// </summary>
+        public string Subtract(string name, string paramA, string paramB)
+        {
+            EnsureParam(paramA);
+            EnsureParam(paramB);
+            var output = MakeAap(name);
+            AddDirect(paramA, MakeSetterClip(output, 1f));
+            AddDirect(paramB, MakeSetterClip(output, -1f));
+            return output;
+        }
+
+        private string _frameTimeParam;
+
+        /// <summary>
+        /// フレームデルタタイムパラメータを取得（遅延初期化）。
+        /// 初回呼び出し時にフレームタイム計測用レイヤーのセットアップをマークする。
+        /// </summary>
+        private string GetOrCreateFrameTime()
+        {
+            if (_frameTimeParam != null) return _frameTimeParam;
+            _needsFrameTimeLayer = true;
+
+            var prefix = string.IsNullOrEmpty(_paramPrefix) ? "__ndmfsps" : _paramPrefix;
+            var timeSinceLoadParam = $"{prefix}/__time";
+            EnsureParam(timeSinceLoadParam);
+
+            var lastTimeParam = Buffer(timeSinceLoadParam, $"{prefix}/__lastTime");
+            _frameTimeParam = Subtract($"{prefix}/__frameTime", timeSinceLoadParam, lastTimeParam);
+            return _frameTimeParam;
+        }
+
+        /// <summary>
+        /// VRCFuryのGetFramesRequired相当。
+        /// fractionPerFrameの速度で2パススムージングした場合に
+        /// 90%に到達するフレーム数を返す。
+        /// </summary>
+        private static int GetFramesRequired(float fractionPerFrame)
+        {
+            var targetFraction = 0.9f;
+            float target = 0f;
+            float position = 0f;
+            for (var frame = 1; frame < 1000; frame++)
+            {
+                target += (1 - target) * fractionPerFrame;
+                position += (target - position) * fractionPerFrame;
+                if (position >= targetFraction) return frame;
+            }
+            return 1000;
+        }
+
+        /// <summary>
+        /// smoothingSecondsからfractionPerSecondを算出する。
+        /// 二分探索で目標フレーム数に合うfractionPerFrameを見つけ、
+        /// それを60倍してfractionPerSecondにする。
+        /// </summary>
+        private static float CalculateFractionPerSecond(float smoothingSeconds)
+        {
+            var framerateForCalculation = 60;
+            var targetFrames = smoothingSeconds * framerateForCalculation;
+            var currentSpeed = 0.5f;
+            var nextStep = 0.25f;
+            for (var i = 0; i < 20; i++)
+            {
+                var currentFrames = GetFramesRequired(currentSpeed);
+                if (currentFrames > targetFrames)
+                    currentSpeed += nextStep;
+                else
+                    currentSpeed -= nextStep;
+                nextStep *= 0.5f;
+            }
+            return currentSpeed * framerateForCalculation;
+        }
+
+        /// <summary>
+        /// 単一パスのスムージング。
+        /// 1D BlendTreeで[maintain current, use target]を速度パラメータで補間する。
+        /// </summary>
+        private string SmoothSinglePass(string name, string targetParam, string speedParam)
+        {
+            var output = MakeAap(name);
+
+            // maintainTree: 現在値を維持 (output → output)
+            var maintainTree = MakeCopier(output, output);
+
+            // targetTree: 目標値にジャンプ (target → output)
+            var targetTree = MakeCopier(targetParam, output);
+
+            // speedで補間: speed=0→maintain, speed=1→target
+            var smoothTree = Make1D(
+                $"{name} smoothto {targetParam}",
+                speedParam,
+                (0f, maintainTree),
+                (1f, targetTree));
+
+            AddDirect(smoothTree);
+            return output;
+        }
+
+        /// <summary>
+        /// パラメータにスムージングを適用する（2パス、加速度付き）。
+        /// VRCFury v1.1001.0のSmoothingService.Smooth相当。
+        /// </summary>
+        public string Smooth(string name, string targetParam, float smoothingSeconds)
+        {
+            if (smoothingSeconds <= 0) return targetParam;
+            if (smoothingSeconds > 10) smoothingSeconds = 10;
+
+            var frameTime = GetOrCreateFrameTime();
+            var fractionPerSecond = CalculateFractionPerSecond(smoothingSeconds);
+            var speedParam = Multiply($"{name}/Speed", frameTime, fractionPerSecond);
+
+            // 2パス: 加速度付きスムージング
+            var pass1 = SmoothSinglePass($"{name}/Pass1", targetParam, speedParam);
+            var pass2 = SmoothSinglePass($"{name}/Pass2", pass1, speedParam);
+            return pass2;
+        }
+
+        /// <summary>
+        /// AnimatorControllerにすべてのレイヤーを追加する。
+        /// フレームタイムレイヤー（必要時）+ DBTレイヤーを作成。
+        /// </summary>
+        public void FinalizeController(string dbtLayerName)
+        {
+            if (_needsFrameTimeLayer)
+            {
+                var prefix = string.IsNullOrEmpty(_paramPrefix) ? "__ndmfsps" : _paramPrefix;
+                var timeSinceLoadParam = $"{prefix}/__time";
+
+                _controller.AddLayer("FrameTime Counter");
+                var ftIdx = _controller.layers.Length - 1;
+                var ftLayer = _controller.layers[ftIdx];
+                ftLayer.defaultWeight = 1f;
+                var layers = _controller.layers;
+                layers[ftIdx] = ftLayer;
+                _controller.layers = layers;
+
+                var clip = new AnimationClip { name = "FrameTime Counter" };
+                clip.SetCurve("", typeof(Animator), timeSinceLoadParam,
+                    AnimationCurve.Linear(0, 0, 10_000_000, 10_000_000));
+
+                var ftState = ftLayer.stateMachine.AddState("Time");
+                ftState.motion = clip;
+                ftState.writeDefaultValues = true;
+            }
+
+            _controller.AddLayer(dbtLayerName);
+            var dbtIdx = _controller.layers.Length - 1;
+            var dbtLayer = _controller.layers[dbtIdx];
+            dbtLayer.defaultWeight = 1f;
+            var dbtLayers = _controller.layers;
+            dbtLayers[dbtIdx] = dbtLayer;
+            _controller.layers = dbtLayers;
+
+            var dbtState = dbtLayer.stateMachine.AddState("DBT");
+            dbtState.motion = _directTree;
+            dbtState.writeDefaultValues = true;
         }
     }
 }

--- a/ndmf_sps/Editor/Processor/AapMath.cs
+++ b/ndmf_sps/Editor/Processor/AapMath.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Animations;
+using UnityEngine;
+
+namespace com.meronmks.ndmfsps
+{
+    /// <summary>
+    /// Direct BlendTree内でAAP (Animator As Property) を使った演算を行うユーティリティ。
+    /// VRCFury v1.1001.0のMathServiceに相当する軽量版。
+    /// </summary>
+    internal class AapMath
+    {
+        private readonly AnimatorController _controller;
+        private readonly BlendTree _directTree;
+        private readonly HashSet<string> _registeredParams = new HashSet<string>();
+
+        private const string AlwaysOneParam = "__ndmfsps_one";
+
+        public BlendTree DirectTree => _directTree;
+
+        public AapMath(AnimatorController controller)
+        {
+            _controller = controller;
+            _directTree = new BlendTree
+            {
+                name = "DBT",
+                blendType = BlendTreeType.Direct,
+                useAutomaticThresholds = false
+            };
+            EnsureParam(AlwaysOneParam, 1f);
+        }
+
+        public void EnsureParam(string name, float defaultValue = 0f)
+        {
+            if (!_registeredParams.Add(name)) return;
+            _controller.AddParameter(new AnimatorControllerParameter
+            {
+                name = name,
+                type = AnimatorControllerParameterType.Float,
+                defaultFloat = defaultValue
+            });
+        }
+
+        public string MakeAap(string name, float defaultValue = 0f)
+        {
+            EnsureParam(name, defaultValue);
+            AddDirect(AlwaysOneParam, MakeSetterClip(name, 0f));
+            return name;
+        }
+
+        public AnimationClip MakeSetterClip(string paramName, float value)
+        {
+            var clip = new AnimationClip { name = $"AAP {paramName}={value}" };
+            var curve = new AnimationCurve(new Keyframe(0f, value));
+            clip.SetCurve("", typeof(Animator), paramName, curve);
+            return clip;
+        }
+
+        public void AddDirect(string blendParam, Motion motion)
+        {
+            _directTree.AddChild(motion);
+            var children = _directTree.children;
+            var child = children[children.Length - 1];
+            child.directBlendParameter = blendParam;
+            children[children.Length - 1] = child;
+            _directTree.children = children;
+        }
+
+        public void AddDirect(Motion motion)
+        {
+            AddDirect(AlwaysOneParam, motion);
+        }
+
+        public BlendTree Make1D(string name, string blendParam, params (float threshold, Motion motion)[] children)
+        {
+            var tree = new BlendTree
+            {
+                name = name,
+                blendType = BlendTreeType.Simple1D,
+                blendParameter = blendParam,
+                useAutomaticThresholds = false
+            };
+            foreach (var (threshold, motion) in children)
+            {
+                tree.AddChild(motion ?? new AnimationClip(), threshold);
+            }
+            return tree;
+        }
+
+        public string Map(string outputName, string inputParam, float inMin, float inMax, float outMin, float outMax)
+        {
+            EnsureParam(inputParam);
+            var output = MakeAap(outputName);
+
+            var minClip = MakeSetterClip(output, outMin);
+            var maxClip = MakeSetterClip(output, outMax);
+
+            BlendTree tree;
+            if (inMin < inMax)
+            {
+                tree = Make1D($"{inputParam} ({inMin}-{inMax}) -> ({outMin}-{outMax})", inputParam,
+                    (inMin, minClip),
+                    (inMax, maxClip));
+            }
+            else
+            {
+                tree = Make1D($"{inputParam} ({inMax}-{inMin}) -> ({outMax}-{outMin})", inputParam,
+                    (inMax, maxClip),
+                    (inMin, minClip));
+            }
+            AddDirect(tree);
+            return output;
+        }
+
+        public delegate Motion ConditionFactory(Motion whenTrue, Motion whenFalse);
+
+        public ConditionFactory GreaterThan(string paramA, float threshold, bool orEqual = false)
+        {
+            EnsureParam(paramA);
+            var belowThreshold = orEqual ? threshold - 0.00001f : threshold;
+            var aboveThreshold = orEqual ? threshold : threshold + 0.00001f;
+            return (whenTrue, whenFalse) => Make1D(
+                $"{paramA} {(orEqual ? ">=" : ">")} {threshold}",
+                paramA,
+                (belowThreshold, whenFalse ?? new AnimationClip()),
+                (aboveThreshold, whenTrue ?? new AnimationClip()));
+        }
+
+        public void SetValueWithConditions(params (Motion motion, ConditionFactory condition)[] targets)
+        {
+            Motion elseTree = null;
+            foreach (var (motion, condition) in targets.Reverse())
+            {
+                if (condition == null)
+                {
+                    elseTree = motion;
+                    continue;
+                }
+                elseTree = condition(motion, elseTree);
+            }
+            if (elseTree != null) AddDirect(elseTree);
+        }
+
+        public Motion MakeCopier(string fromParam, string toParam)
+        {
+            EnsureParam(fromParam);
+            var subTree = new BlendTree
+            {
+                name = $"Copy {fromParam} -> {toParam}",
+                blendType = BlendTreeType.Direct,
+                useAutomaticThresholds = false
+            };
+            var setterClip = MakeSetterClip(toParam, 1f);
+            subTree.AddChild(setterClip);
+            var children = subTree.children;
+            var child = children[0];
+            child.directBlendParameter = fromParam;
+            children[0] = child;
+            subTree.children = children;
+            return subTree;
+        }
+
+        public Motion MakeConstSetter(string toParam, float value)
+        {
+            return MakeSetterClip(toParam, value);
+        }
+    }
+}

--- a/ndmf_sps/Editor/Processor/AapMath.cs
+++ b/ndmf_sps/Editor/Processor/AapMath.cs
@@ -144,13 +144,44 @@ namespace com.meronmks.ndmfsps
         public ConditionFactory GreaterThan(string paramA, float threshold, bool orEqual = false)
         {
             EnsureParam(paramA);
-            var belowThreshold = orEqual ? threshold - 0.00001f : threshold;
-            var aboveThreshold = orEqual ? threshold : threshold + 0.00001f;
+            var belowThreshold = orEqual ? NextFloatDown(threshold) : threshold;
+            var aboveThreshold = orEqual ? threshold : NextFloatUp(threshold);
             return (whenTrue, whenFalse) => Make1D(
                 $"{paramA} {(orEqual ? ">=" : ">")} {threshold}",
                 paramA,
                 (belowThreshold, whenFalse ?? new AnimationClip()),
                 (aboveThreshold, whenTrue ?? new AnimationClip()));
+        }
+
+        /// <summary>
+        /// IEEE 754 の最小精度で次に大きいfloatを返す
+        /// </summary>
+        private static float NextFloatUp(float input)
+        {
+            return NextFloat(input, 1);
+        }
+
+        /// <summary>
+        /// IEEE 754 の最小精度で次に小さいfloatを返す
+        /// </summary>
+        private static float NextFloatDown(float input)
+        {
+            return NextFloat(input, -1);
+        }
+
+        private static float NextFloat(float input, int offset)
+        {
+            if (float.IsNaN(input) || float.IsPositiveInfinity(input) || float.IsNegativeInfinity(input))
+                return input;
+            if (input == 0)
+                return (offset > 0) ? float.Epsilon : -float.Epsilon;
+
+            var bytes = BitConverter.GetBytes(input);
+            var bits = BitConverter.ToInt32(bytes, 0);
+            if (input > 0) bits += offset;
+            else bits -= offset;
+            bytes = BitConverter.GetBytes(bits);
+            return BitConverter.ToSingle(bytes, 0);
         }
 
         public void SetValueWithConditions(params (Motion motion, ConditionFactory condition)[] targets)

--- a/ndmf_sps/Editor/Processor/AapMath.cs
+++ b/ndmf_sps/Editor/Processor/AapMath.cs
@@ -93,6 +93,12 @@ namespace com.meronmks.ndmfsps
         public string Map(string outputName, string inputParam, float inMin, float inMax, float outMin, float outMax)
         {
             EnsureParam(inputParam);
+            if (Math.Abs(inMax - inMin) < 0.00001f)
+            {
+                var output2 = MakeAap(outputName);
+                AddDirect(MakeSetterClip(output2, outMin));
+                return output2;
+            }
             var output = MakeAap(outputName);
 
             var minClip = MakeSetterClip(output, outMin);

--- a/ndmf_sps/Editor/Processor/AapMath.cs
+++ b/ndmf_sps/Editor/Processor/AapMath.cs
@@ -16,6 +16,7 @@ namespace com.meronmks.ndmfsps
         private readonly AnimatorController _controller;
         private readonly BlendTree _directTree;
         private readonly HashSet<string> _registeredParams = new HashSet<string>();
+        private readonly Dictionary<string, float> _paramDefaults = new Dictionary<string, float>();
         private readonly string _paramPrefix;
         private bool _needsFrameTimeLayer;
 
@@ -39,12 +40,18 @@ namespace com.meronmks.ndmfsps
         public void EnsureParam(string name, float defaultValue = 0f)
         {
             if (!_registeredParams.Add(name)) return;
+            _paramDefaults[name] = defaultValue;
             _controller.AddParameter(new AnimatorControllerParameter
             {
                 name = name,
                 type = AnimatorControllerParameterType.Float,
                 defaultFloat = defaultValue
             });
+        }
+
+        public float GetDefault(string name)
+        {
+            return _paramDefaults.TryGetValue(name, out var val) ? val : 0f;
         }
 
         public string MakeAap(string name, float defaultValue = 0f)
@@ -96,13 +103,20 @@ namespace com.meronmks.ndmfsps
         public string Map(string outputName, string inputParam, float inMin, float inMax, float outMin, float outMax)
         {
             EnsureParam(inputParam);
+            // 入力パラメータのデフォルト値から出力デフォルトを計算
+            var inputDefault = GetDefault(inputParam);
+            var outputDefault = (inMax - inMin) != 0
+                ? outMin + (outMax - outMin) * (inputDefault - inMin) / (inMax - inMin)
+                : outMin;
+            outputDefault = Math.Min(Math.Max(outputDefault, Math.Min(outMin, outMax)), Math.Max(outMin, outMax));
+
             if (Math.Abs(inMax - inMin) < 0.00001f)
             {
-                var output2 = MakeAap(outputName);
+                var output2 = MakeAap(outputName, outputDefault);
                 AddDirect(MakeSetterClip(output2, outMin));
                 return output2;
             }
-            var output = MakeAap(outputName);
+            var output = MakeAap(outputName, outputDefault);
 
             var minClip = MakeSetterClip(output, outMin);
             var maxClip = MakeSetterClip(output, outMax);
@@ -283,7 +297,7 @@ namespace com.meronmks.ndmfsps
         /// </summary>
         private string SmoothSinglePass(string name, string targetParam, string speedParam)
         {
-            var output = MakeAap(name);
+            var output = MakeAap(name, GetDefault(targetParam));
 
             // maintainTree: 現在値を維持 (output → output)
             var maintainTree = MakeCopier(output, output);

--- a/ndmf_sps/Editor/Processor/Processor.cs
+++ b/ndmf_sps/Editor/Processor/Processor.cs
@@ -43,7 +43,11 @@ namespace com.meronmks.ndmfsps
         {
             Self,
             Others,
-            Both
+            Both,
+            /// <summary>
+            /// allowSelf=true, allowOthers=trueの単一Contact Receiverを作成（分割しない）
+            /// </summary>
+            BothCombined
         }
 
         internal static void FindSpsComponents(BuildContext ctx)
@@ -304,8 +308,8 @@ namespace com.meronmks.ndmfsps
             receiver.shapeType = ContactBase.ShapeType.Sphere;
             receiver.radius = radius;
             receiver.position = pos;
-            receiver.allowSelf = party == ReceiverParty.Self;
-            receiver.allowOthers = party == ReceiverParty.Others;
+            receiver.allowSelf = party == ReceiverParty.Self || party == ReceiverParty.BothCombined;
+            receiver.allowOthers = party == ReceiverParty.Others || party == ReceiverParty.BothCombined;
             receiver.localOnly = localOnly;
             receiver.receiverType = receiverType;
             receiver.parameter = parameter;

--- a/ndmf_sps/Editor/Processor/SocketProcessor.cs
+++ b/ndmf_sps/Editor/Processor/SocketProcessor.cs
@@ -483,7 +483,7 @@ namespace com.meronmks.ndmfsps
             var onClip = animClipTuple.Item1;
             var offClip = animClipTuple.Item2;
 
-            if (onClip.length > 0)
+            if (!IsStaticClip(onClip))
             {
                 // Non-static clip: MotionTimeで駆動（タイムライン上の位置をMappedで制御）
                 var settings = AnimationUtility.GetAnimationClipSettings(onClip);
@@ -523,6 +523,32 @@ namespace com.meronmks.ndmfsps
             maMergeAnimator.animator = controller;
             maMergeAnimator.layerType = VRCAvatarDescriptor.AnimLayerType.FX;
             maMergeAnimator.matchAvatarWriteDefaults = true;
+        }
+
+        /// <summary>
+        /// AnimationClipが静的（全カーブの全キーフレームがtime=0かつ同一値）かどうかを判定する。
+        /// VRCFuryのMotionExtensions.IsStatic相当。
+        /// </summary>
+        private static bool IsStaticClip(AnimationClip clip)
+        {
+            foreach (var binding in AnimationUtility.GetCurveBindings(clip))
+            {
+                var curve = AnimationUtility.GetEditorCurve(clip, binding);
+                if (curve == null) continue;
+                var keys = curve.keys;
+                if (keys.Length == 0) continue;
+                if (keys.All(key => key.time != 0)) return false;
+                if (keys.Select(k => k.value).Distinct().Count() > 1) return false;
+            }
+            foreach (var binding in AnimationUtility.GetObjectReferenceCurveBindings(clip))
+            {
+                var keys = AnimationUtility.GetObjectReferenceCurve(clip, binding);
+                if (keys == null) continue;
+                if (keys.Length == 0) continue;
+                if (keys.All(key => key.time != 0)) return false;
+                if (keys.Select(k => k.value).Distinct().Count() > 1) return false;
+            }
+            return true;
         }
 
         internal static void CreateActiveAnimations(BuildContext ctx, Socket socket, List<IAction> actions)

--- a/ndmf_sps/Editor/Processor/SocketProcessor.cs
+++ b/ndmf_sps/Editor/Processor/SocketProcessor.cs
@@ -480,16 +480,33 @@ namespace com.meronmks.ndmfsps
             offState.motion = emptyClip;
             
             var animClipTuple = Processor.CreateAnimationClip(ctx, socket.gameObject, depthAction.actions, onState);
-            
-            var blendTree = new BlendTree();
-            blendTree.name = $"{objectName}Tree {count}";
-            blendTree.blendType = BlendTreeType.Simple1D;
-            blendTree.blendParameter = parmName;
-            blendTree.useAutomaticThresholds = false;
-            blendTree.AddChild(animClipTuple.Item2, 0f);
-            blendTree.AddChild(animClipTuple.Item1, 1f);
-            
-            onState.motion = blendTree;
+            var onClip = animClipTuple.Item1;
+            var offClip = animClipTuple.Item2;
+
+            if (onClip.length > 0)
+            {
+                // Non-static clip: MotionTimeで駆動（タイムライン上の位置をMappedで制御）
+                var settings = AnimationUtility.GetAnimationClipSettings(onClip);
+                settings.loopTime = false;
+                AnimationUtility.SetAnimationClipSettings(onClip, settings);
+
+                onState.motion = onClip;
+                onState.timeParameterActive = true;
+                onState.timeParameter = parmName;
+            }
+            else
+            {
+                // Static clip: BlendTreeで0→off, 1→onをブレンド
+                var blendTree = new BlendTree();
+                blendTree.name = $"{objectName}Tree {count}";
+                blendTree.blendType = BlendTreeType.Simple1D;
+                blendTree.blendParameter = parmName;
+                blendTree.useAutomaticThresholds = false;
+                blendTree.AddChild(offClip, 0f);
+                blendTree.AddChild(onClip, 1f);
+
+                onState.motion = blendTree;
+            }
 
             var onTransition = offState.AddTransition(onState);
             var offTransition = onState.AddTransition(offState);

--- a/ndmf_sps/Editor/Processor/SocketProcessor.cs
+++ b/ndmf_sps/Editor/Processor/SocketProcessor.cs
@@ -289,89 +289,144 @@ namespace com.meronmks.ndmfsps
         }
         
         /// <summary>
-        /// Plugの位置によって動くContact
+        /// Plugの位置によって動くContactとAAP距離計算
         /// </summary>
-        /// <param name="root"></param>
         internal static void CreateVRCContacts(BuildContext ctx, Transform root, Socket socket)
         {
             var animator = ctx.AvatarRootObject.GetComponent<Animator>();
-            
-            var maxDist = Math.Max(0, socket.depthActions.Max(a => Math.Max(a.startDistance, a.endDistance)));
-            var minDist = Math.Min(0, socket.depthActions.Min(a => Math.Min(a.startDistance, a.endDistance)));
-            // var offset = Math.Max(0, -minDist);
+            var objectName = root.gameObject.name.Replace("/", "_");
+            var scale = socket.unitsInMeters ? 1f : root.lossyScale.z;
 
-            var cache = new Dictionary<bool, bool>();
+            var maxDist = Math.Max(0, socket.depthActions.Max(a => Math.Max(a.startDistance, a.endDistance))) * scale;
+            var minDist = Math.Min(0, socket.depthActions.Min(a => Math.Min(a.startDistance, a.endDistance))) * scale;
+            var offset = Math.Max(0, -minDist);
 
-            foreach (var depthAction in socket.depthActions)
+            var controller = new AnimatorController();
+            var math = new AapMath(controller);
+
+            // enableSelf ごとに距離計算用のContactとAAPを作成
+            var distanceParams = new Dictionary<bool, string>();
+
+            var enableSelfValues = socket.depthActions.Select(a => a.enableSelf).Distinct();
+            foreach (var enableSelf in enableSelfValues)
             {
-                if(cache.ContainsKey(depthAction.enableSelf)) continue;
-                cache[depthAction.enableSelf] = true;
+                var animParmPrefix = $"{objectName}/Anim{(enableSelf ? "" : "Others")}";
+                var outerRadius = Math.Max(0.01f, maxDist);
+                var party = enableSelf ? Processor.ReceiverParty.BothCombined : Processor.ReceiverParty.Others;
+
+                // Outer Front contact
                 var animationsRoot = Processor.CreateParentGameObject("Animations", root);
                 var outerGameObject = Processor.CreateParentGameObject("Outer", animationsRoot.transform);
                 var frontGameObject = Processor.CreateParentGameObject("Front", outerGameObject.transform);
-                var backGameObject = Processor.CreateParentGameObject("Back", outerGameObject.transform);
-                
-                var animParmPrefix = $"{root.gameObject.name.Replace("/", "_")}/Anim{(depthAction.enableSelf ? "" : "Others")}";
-                var outerRadius = Math.Max(0.01f, maxDist);
-                
+
+                var outerFrontParam = $"{animParmPrefix}/Outer/Front";
                 Processor.CreateVRCContactReceiver(
                     frontGameObject,
                     outerRadius,
                     Vector3.zero,
-                    new []
-                    {
-                        "TPS_Pen_Penetrating"
-                    },
-                    $"{animParmPrefix}/Outer/Front",
+                    new[] { "TPS_Pen_Penetrating" },
+                    outerFrontParam,
                     animator,
-                    depthAction.enableSelf ? Processor.ReceiverParty.Both : Processor.ReceiverParty.Others,
+                    party,
                     useHipAvoidance: socket.useHipAvoidance);
-                Processor.CreateVRCContactReceiver(
-                    backGameObject,
-                    outerRadius,
-                    Vector3.zero + Vector3.forward * -0.01f,
-                    new []
-                    {
-                        "TPS_Pen_Penetrating"
-                    },
-                    $"{animParmPrefix}/Outer/Back",
-                    animator,
-                    depthAction.enableSelf ? Processor.ReceiverParty.Both : Processor.ReceiverParty.Others,
-                    useHipAvoidance: socket.useHipAvoidance);
+
+                // Inner Front contact (負距離がある場合のみ)
+                string innerFrontParam = null;
                 if (minDist < 0)
                 {
                     var innerGameObject = Processor.CreateParentGameObject("Inner", animationsRoot.transform);
                     var frontInnerGameObject = Processor.CreateParentGameObject("Front", innerGameObject.transform);
-                    var backInnerGameObject = Processor.CreateParentGameObject("Back", innerGameObject.transform);
-                    
-                    var posOffset = Vector3.forward * minDist;
-                    
+
+                    innerFrontParam = $"{animParmPrefix}/Inner/Front";
                     Processor.CreateVRCContactReceiver(
                         frontInnerGameObject,
-                        -minDist,
-                        posOffset,
-                        new []
-                        {
-                            "TPS_Pen_Penetrating"
-                        },
-                        $"{animParmPrefix}/Inner/Front",
+                        -minDist / scale,
+                        Vector3.forward * (minDist / scale),
+                        new[] { "TPS_Pen_Penetrating" },
+                        innerFrontParam,
                         animator,
-                        depthAction.enableSelf ? Processor.ReceiverParty.Both : Processor.ReceiverParty.Others,
-                        useHipAvoidance: socket.useHipAvoidance);
-                    Processor.CreateVRCContactReceiver(
-                        backInnerGameObject,
-                        -minDist,
-                        posOffset + Vector3.forward * -0.01f,
-                        new []
-                        {
-                            "TPS_Pen_Penetrating"
-                        },
-                        $"{animParmPrefix}/Inner/Back",
-                        animator,
-                        depthAction.enableSelf ? Processor.ReceiverParty.Both : Processor.ReceiverParty.Others,
+                        party,
                         useHipAvoidance: socket.useHipAvoidance);
                 }
+
+                // ---- AAP距離計算 ----
+                var distanceParam = $"{animParmPrefix}/Distance";
+                math.MakeAap(distanceParam, offset + outerRadius);
+
+                var targets = new List<(Motion motion, AapMath.ConditionFactory condition)>();
+
+                if (minDist < 0 && innerFrontParam != null)
+                {
+                    // Inner距離: Plugが完全にSocket内部 (outer.front >= 1)
+                    var innerDistParam = math.Map(
+                        $"{animParmPrefix}/Inner/Distance",
+                        innerFrontParam,
+                        1f, 0f,
+                        offset + minDist, offset + 0f);
+
+                    targets.Add((
+                        math.MakeCopier(innerDistParam, distanceParam),
+                        math.GreaterThan(outerFrontParam, 1f, orEqual: true)
+                    ));
+                }
+
+                if (maxDist > 0)
+                {
+                    // Outer距離: Plugが外側にいる (outer.front > 0)
+                    var outerDistParam = math.Map(
+                        $"{animParmPrefix}/Outer/Distance",
+                        outerFrontParam,
+                        1f, 0f,
+                        offset + 0f, offset + outerRadius);
+
+                    targets.Add((
+                        math.MakeCopier(outerDistParam, distanceParam),
+                        math.GreaterThan(outerFrontParam, 0f)
+                    ));
+                }
+
+                // フォールバック: 最大距離
+                targets.Add((
+                    math.MakeConstSetter(distanceParam, offset + outerRadius),
+                    null
+                ));
+
+                math.SetValueWithConditions(targets.ToArray());
+
+                distanceParams[enableSelf] = distanceParam;
             }
+
+            // 各DepthActionのMappedパラメータを計算
+            for (var i = 0; i < socket.depthActions.Count; i++)
+            {
+                var depthAction = socket.depthActions[i];
+                var mappedParam = $"{objectName}/Anim{i}/Mapped";
+                var distanceParam = distanceParams[depthAction.enableSelf];
+
+                math.Map(
+                    mappedParam,
+                    distanceParam,
+                    offset + depthAction.startDistance * scale,
+                    offset + depthAction.endDistance * scale,
+                    0f, 1f);
+            }
+
+            // AnimatorControllerにDBTレイヤーを設定しMergeAnimatorでアタッチ
+            controller.AddLayer($"SPS Depth Calc for {objectName}");
+            var layer = controller.layers[0];
+            layer.defaultWeight = 1f;
+            var layers = controller.layers;
+            layers[0] = layer;
+            controller.layers = layers;
+
+            var state = layer.stateMachine.AddState("DBT");
+            state.motion = math.DirectTree;
+            state.writeDefaultValues = true;
+
+            var maMergeAnimator = root.gameObject.AddComponent<ModularAvatarMergeAnimator>();
+            maMergeAnimator.animator = controller;
+            maMergeAnimator.layerType = VRCAvatarDescriptor.AnimLayerType.FX;
+            maMergeAnimator.matchAvatarWriteDefaults = true;
         }
         
         /// <summary>

--- a/ndmf_sps/Editor/Processor/SocketProcessor.cs
+++ b/ndmf_sps/Editor/Processor/SocketProcessor.cs
@@ -303,7 +303,7 @@ namespace com.meronmks.ndmfsps
             var offset = Math.Max(0, -minDist);
 
             var controller = new AnimatorController();
-            var math = new AapMath(controller);
+            var math = new AapMath(controller, objectName);
 
             // enableSelf ごとに距離計算用のContactとAAPを作成
             var distanceParams = new Dictionary<bool, string>();
@@ -404,25 +404,30 @@ namespace com.meronmks.ndmfsps
                 var mappedParam = $"{objectName}/Anim{i}/Mapped";
                 var distanceParam = distanceParams[depthAction.enableSelf];
 
-                math.Map(
-                    mappedParam,
-                    distanceParam,
-                    offset + depthAction.startDistance * scale,
-                    offset + depthAction.endDistance * scale,
-                    0f, 1f);
+                if (depthAction.smoothingSeconds > 0)
+                {
+                    var rawMappedParam = $"{objectName}/Anim{i}/RawMapped";
+                    math.Map(
+                        rawMappedParam,
+                        distanceParam,
+                        offset + depthAction.startDistance * scale,
+                        offset + depthAction.endDistance * scale,
+                        0f, 1f);
+                    math.Smooth(mappedParam, rawMappedParam, depthAction.smoothingSeconds);
+                }
+                else
+                {
+                    math.Map(
+                        mappedParam,
+                        distanceParam,
+                        offset + depthAction.startDistance * scale,
+                        offset + depthAction.endDistance * scale,
+                        0f, 1f);
+                }
             }
 
-            // AnimatorControllerにDBTレイヤーを設定しMergeAnimatorでアタッチ
-            controller.AddLayer($"SPS Depth Calc for {objectName}");
-            var layer = controller.layers[0];
-            layer.defaultWeight = 1f;
-            var layers = controller.layers;
-            layers[0] = layer;
-            controller.layers = layers;
-
-            var state = layer.stateMachine.AddState("DBT");
-            state.motion = math.DirectTree;
-            state.writeDefaultValues = true;
+            // AnimatorControllerにレイヤーを設定しMergeAnimatorでアタッチ
+            math.FinalizeController($"SPS Depth Calc for {objectName}");
 
             var maMergeAnimator = root.gameObject.AddComponent<ModularAvatarMergeAnimator>();
             maMergeAnimator.animator = controller;

--- a/ndmf_sps/Editor/Processor/SocketProcessor.cs
+++ b/ndmf_sps/Editor/Processor/SocketProcessor.cs
@@ -294,6 +294,7 @@ namespace com.meronmks.ndmfsps
         internal static void CreateVRCContacts(BuildContext ctx, Transform root, Socket socket)
         {
             var animator = ctx.AvatarRootObject.GetComponent<Animator>();
+            if (socket.depthActions.Count == 0) return;
             var objectName = root.gameObject.name.Replace("/", "_");
             var scale = socket.unitsInMeters ? 1f : root.lossyScale.z;
 
@@ -340,8 +341,8 @@ namespace com.meronmks.ndmfsps
                     innerFrontParam = $"{animParmPrefix}/Inner/Front";
                     Processor.CreateVRCContactReceiver(
                         frontInnerGameObject,
-                        -minDist / scale,
-                        Vector3.forward * (minDist / scale),
+                        -minDist,
+                        Vector3.forward * minDist,
                         new[] { "TPS_Pen_Penetrating" },
                         innerFrontParam,
                         animator,


### PR DESCRIPTION
## Summary

- SocketのContact Receiver近接度値からDirect BlendTree + AAP演算で距離を計算し、各DepthActionの`Mapped`パラメータに書き込むロジックを追加
- VRCFury v1.1001.0の`HapticAnimContactsService.CreateSocketAnims`と同等の実装（末尾の比較レビューで全項目「同等」判定）

Resolves #16

## Changes

- **`AapMath.cs` (新規)**: Direct BlendTree内でのAAP演算ユーティリティ
  - 基本演算: Map, Multiply, Subtract, Buffer, MakeCopier
  - 条件分岐: GreaterThan (IEEE 754 ULP精度), SetValueWithConditions
  - スムージング: フレームタイム検出 + 2パス指数移動平均 + Speedキャッシュ
- **`Processor.cs`**: `ReceiverParty.BothCombined`を追加 (allowSelf=true, allowOthers=trueの単一Contact Receiver。VRCFuryの2受信器+Max方式と機能的に同等で、コンタクト使用数が少ない)
- **`SocketProcessor.cs`**:
  - `CreateVRCContacts`を書き換え — Contact作成 + AAP距離計算 + スムージング + Mapped出力
  - `CreateDepthAnims`を修正 — Non-staticクリップのMotionTime駆動に対応、IsStatic判定をVRCFury準拠に変更

## How it works

```
Contact Receiver (proximity 0~1)
  → AAP距離計算 (条件分岐: Plug内側/外側/未検出)
  → Map (距離 → RawMapped [0,1])
  → Smooth (RawMapped → Mapped, 2パス指数移動平均)
  → CreateDepthAnims:
      Static clip → BlendTreeで[0→off, 1→on]をブレンド
      Non-static clip → MotionTimeでタイムライン位置をMappedで制御
```

## VRCFury v1.1001.0 との対応

| 項目 | 判定 |
|------|------|
| 距離計算 (Contact構成, Map, 条件分岐) | 同等 |
| Self/Others (BothCombined vs Both+Max) | 機能的に同等 |
| Back Contact | ndmf_spsが正しく省略 |
| AAP演算 (MakeAap, Map, MakeCopier, Multiply) | 同等 (デフォルト値計算含む) |
| GreaterThan精度 | 同等 (IEEE 754 ULP) |
| スムージング (2パス, 二分探索, フレームタイム, Speedキャッシュ) | 同等 |
| アニメーション駆動 (Static/MotionTime) | 同等 |

## Test plan

- [ ] SocketにDepthActionを設定したアバターでビルドが通ることを確認
- [ ] Depth Animationが実際にPlugの距離に応じて動作することを確認
- [ ] smoothingSecondsの値を変えてスムージングが効いていることを確認
- [ ] Non-staticなAnimationClipをDepthActionに設定してMotionTime駆動を確認
- [ ] enableSelf=true/false両方のケースでテスト
- [ ] depthActionsが空の場合にクラッシュしないことを確認

## Notes

- 将来的にはVRCFury現行版のTip/Root/Width方式への移行を予定（別PR）
- Plug側のDepthAnimsにも同様の問題があるが今回はSocket側のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<details>
<summary>VRCFury v1.1001.0 vs ndmf_sps 詳細比較レビュー</summary>

比較対象:
- **VRCFury**: tag `com.vrcfury.vrcfury/1.1001.0` (commit `e771e781`)
- **ndmf_sps**: branch `feat/socket-depth-aap-calculation` 最新コミット

### 比較対象ファイル

| ndmf_sps | VRCFury 1.1001.0 |
|----------|------------------|
| `SocketProcessor.cs` (`CreateVRCContacts`) | `HapticAnimContactsService.cs` (`CreateSocketAnims`) |
| `SocketProcessor.cs` (`CreateDepthAnims`) | `HapticAnimContactsService.cs` (同メソッド内のアニメーション駆動部分) |
| `AapMath.cs` | `MathService.cs` |
| `AapMath.cs` (Smooth/FrameTime) | `SmoothingService.cs` + `FrameTimeService.cs` |
| `Processor.cs` (`ReceiverParty`, `CreateVRCContactReceiver`) | `HapticUtils.cs` (`ReceiverParty`) + `HapticContactsService.cs` (`AddReceiver`) |

> 1.1001.0 時点では `SpsDepthContacts.cs` は存在せず、距離計算は `HapticAnimContactsService.CreateSocketAnims` に直接含まれている。

### 1. 距離計算ロジック — 同等

**maxDist / minDist / offset 計算**: `worldScale` ↔ `unitsInMeters`、`animRoot.worldScale.z` ↔ `root.lossyScale.z` の対応で同一。

**Contact Receiver 構成**: タグ(`TPS_Pen_Penetrating`)、半径(`max(0.01, maxDist)` / `-minDist`)、位置(`zero` / `forward*minDist`)、作成条件(`minDist < 0`)すべて一致。

**AAP 距離計算 (条件分岐)**: Inner(plug内部: `outer.front >= 1`) → Outer(plug外側: `outer.front > 0`) → フォールバック(`offset+outerRadius`) の順序・Map範囲すべて一致。

### 2. Self/Others ハンドリング — 機能的に同等

VRCFury: `ReceiverParty.Both` → 2受信器 + `Max(others, self)`
ndmf_sps: `ReceiverParty.BothCombined` → 1受信器 (`allowSelf+allowOthers`)

VRC Contact 仕様上、単一受信器は最も近い proximity を返すため結果は同一。ndmf_sps の方がコンタクト消費が少ない。

### 3. Back Contact — ndmf_sps が正しく省略

VRCFury は `CreateFrontBack` で Front + Back を作成するが、`CreateSocketAnims` では `.back` を一切参照していない。ndmf_sps は Front のみ作成。

### 4. AAP 基本操作

- **MakeAap**: 両方とも重み1で0をセット (weight protection)。同一。
- **Map**: デフォルト値計算 (入力デフォルトからリニア補間+クランプ)、1D BlendTree 構成すべて一致。
- **GreaterThan**: 両方とも IEEE 754 ビット演算 (`NextFloatUp`/`NextFloatDown`)。ndmf_sps に NaN/Infinity ガードが追加されているが深度パラメータでは影響なし。
- **SetValueWithConditions**: 設計パターンは異なるが生成ツリーは同構造。
- **MakeCopier**: 両方とも Direct BlendTree で `to = from * 1`。
- **Multiply**: 両方とも `output = param * constant`。

### 5. スムージング — 同等

- **Smooth全体**: 早期リターン(`<= 0`)、上限クランプ(`> 10 → 10`)、2パス構成すべて一致。
- **Speedキャッシュ**: 両方とも同一 `smoothingSeconds` のSpeedパラメータを共有。
- **GetFramesRequired**: 同一 (`target=0`、90%到達フレーム数)。
- **二分探索**: `framerateForCalculation=60`、20回反復。同一。
- **SmoothSinglePass**: `MakeAap(name, target.GetDefault())`、maintain/target copier、`Make1D(speed, (0,maintain), (1,target))`。同一。

### 6. フレームタイム計算 — 同等

タイマー曲線 (`Linear(0,0,10M,10M)`)、レイヤー名 (`"FrameTime Counter"`)、差分計算 (`Subtract(time, Buffer(time))`) すべて一致。

### 7. Depth Action マッピング — 同等

`Map(distance, [offset+startDist*scale, offset+endDist*scale] → [0, 1])` → `Smooth(mapped, seconds)` のフロー一致。

### 8. アニメーション駆動 — 同等

- **Static判定**: VRCFury `IsStatic()` (全カーブ: time=0かつ同一値) vs ndmf_sps `IsStaticClip()` (同一ロジック)。VRCFury の `IsProxyClip()` チェックは深度アニメーションでは影響なし。
- **Static → BlendTree**: `(0→off, 1→on)` で一致。
- **Non-static → MotionTime**: ループ無効化 + timeParameter 設定で一致。
- **遷移条件**: `> 0.01f` / `< 0.01f` で一致。

### 9. アーキテクチャの違い（機能差異なし）

| | VRCFury 1.1001.0 | ndmf_sps |
|-|-------------------|----------|
| DBT 構成 | `DirectBlendTreeService` でビルダー単位の共有 DBT | ソケットごとに個別の `AnimatorController` + DBT |
| パラメータ管理 | `ControllerManager` 経由 | `ModularAvatarMergeAnimator` で個別マージ |

生成される Animator の動作は同一。

### 総合判定

全カテゴリで**同等**。コアのアニメーション計算（距離計測 → Map → Smooth → アニメーション駆動）は VRCFury v1.1001.0 と同義。

</details>