### PR TITLE
feat: Socket に position/rotation フィールドと BakedSpsSocket 中間オブジェクトを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - NDMF ParameterProviderに対応
 - メニューの導入位置をカスタムする用のPrefabを追加
+- Socketに位置・回転のオフセットを指定するフィールドを追加
 
 ### Changed
 - PlugのコンポーネントにVRCFuryが存在しない場合エラーとなることを記載
+- SocketのSenders/Lights/Haptics/Animations/AutoDistanceをBakedSpsSocket中間オブジェクト配下に生成するよう変更（VRCFuryとの互換性向上）
 
 ### Deprecated
 

--- a/ndmf_sps/Editor/CustomEditor/SocketEditor.cs
+++ b/ndmf_sps/Editor/CustomEditor/SocketEditor.cs
@@ -96,20 +96,6 @@ namespace com.meronmks.ndmfsps
             if (advancedFoldout)
             {
                 EditorGUI.indentLevel++;
-                var pPosition = serializedObject.FindProperty(nameof(Socket.position));
-                EditorGUI.BeginChangeCheck();
-                EditorGUILayout.PropertyField(pPosition, Localization.G("inspector.socket.position"));
-                if (EditorGUI.EndChangeCheck())
-                {
-                    serializedObject.ApplyModifiedProperties();
-                }
-                var pRotation = serializedObject.FindProperty(nameof(Socket.rotation));
-                EditorGUI.BeginChangeCheck();
-                EditorGUILayout.PropertyField(pRotation, Localization.G("inspector.socket.rotation"));
-                if (EditorGUI.EndChangeCheck())
-                {
-                    serializedObject.ApplyModifiedProperties();
-                }
                 var pUseHipAvoidance = serializedObject.FindProperty(nameof(Socket.useHipAvoidance));
                 EditorGUI.BeginChangeCheck();
                 EditorGUILayout.PropertyField(pUseHipAvoidance, Localization.G("inspector.common.useHipAvoidance"));
@@ -120,6 +106,20 @@ namespace com.meronmks.ndmfsps
                 var pUnitsInMeters = serializedObject.FindProperty(nameof(Socket.unitsInMeters));
                 EditorGUI.BeginChangeCheck();
                 EditorGUILayout.PropertyField(pUnitsInMeters, Localization.G("inspector.common.unitsInMeters"));
+                if (EditorGUI.EndChangeCheck())
+                {
+                    serializedObject.ApplyModifiedProperties();
+                }
+                var pPosition = serializedObject.FindProperty(nameof(Socket.position));
+                EditorGUI.BeginChangeCheck();
+                EditorGUILayout.PropertyField(pPosition, Localization.G("inspector.socket.position"));
+                if (EditorGUI.EndChangeCheck())
+                {
+                    serializedObject.ApplyModifiedProperties();
+                }
+                var pRotation = serializedObject.FindProperty(nameof(Socket.rotation));
+                EditorGUI.BeginChangeCheck();
+                EditorGUILayout.PropertyField(pRotation, Localization.G("inspector.socket.rotation"));
                 if (EditorGUI.EndChangeCheck())
                 {
                     serializedObject.ApplyModifiedProperties();

--- a/ndmf_sps/Editor/CustomEditor/SocketEditor.cs
+++ b/ndmf_sps/Editor/CustomEditor/SocketEditor.cs
@@ -96,6 +96,20 @@ namespace com.meronmks.ndmfsps
             if (advancedFoldout)
             {
                 EditorGUI.indentLevel++;
+                var pPosition = serializedObject.FindProperty(nameof(Socket.position));
+                EditorGUI.BeginChangeCheck();
+                EditorGUILayout.PropertyField(pPosition, Localization.G("inspector.socket.position"));
+                if (EditorGUI.EndChangeCheck())
+                {
+                    serializedObject.ApplyModifiedProperties();
+                }
+                var pRotation = serializedObject.FindProperty(nameof(Socket.rotation));
+                EditorGUI.BeginChangeCheck();
+                EditorGUILayout.PropertyField(pRotation, Localization.G("inspector.socket.rotation"));
+                if (EditorGUI.EndChangeCheck())
+                {
+                    serializedObject.ApplyModifiedProperties();
+                }
                 var pUseHipAvoidance = serializedObject.FindProperty(nameof(Socket.useHipAvoidance));
                 EditorGUI.BeginChangeCheck();
                 EditorGUILayout.PropertyField(pUseHipAvoidance, Localization.G("inspector.common.useHipAvoidance"));

--- a/ndmf_sps/Editor/Localization/en-US.json
+++ b/ndmf_sps/Editor/Localization/en-US.json
@@ -15,6 +15,8 @@
   "inspector.socket.enableActiveAnimation": "Enable Active actions",
   "inspector.socket.activeAnimationActions": "Actions",
   "inspector.socket.haptics": "Haptics",
+  "inspector.socket.position": "Position",
+  "inspector.socket.rotation": "Rotation",
   "inspector.action.none": "None",
   "inspector.action.objectToggleAction.Obj": "target",
   "inspector.plug.automaticallyFindMesh": "Automatically find mesh",

--- a/ndmf_sps/Editor/Localization/ja-JP.json
+++ b/ndmf_sps/Editor/Localization/ja-JP.json
@@ -15,6 +15,8 @@
   "inspector.socket.enableActiveAnimation": "ソケット有効時に同時にアクションを起こす",
   "inspector.socket.activeAnimationActions": "アクション一覧",
   "inspector.socket.haptics": "ハプティック",
+  "inspector.socket.position": "位置",
+  "inspector.socket.rotation": "回転",
   "inspector.action.none": "None",
   "inspector.action.objectToggleAction.Obj": "対象のオブジェクト",
   "inspector.plug.automaticallyFindMesh": "自動で対象メッシュを選択する",

--- a/ndmf_sps/Editor/Processor/Processor.cs
+++ b/ndmf_sps/Editor/Processor/Processor.cs
@@ -58,14 +58,19 @@ namespace com.meronmks.ndmfsps
             
             foreach (var socket in sockets)
             {
-                SocketProcessor.CreateSender(animator, socket.transform, socket);
-                SocketProcessor.CreateLights(socket.transform, socket.mode);
-                SocketProcessor.CreateHaptics(ctx, animator, socket.transform, socket);
+                var bakedSpsSocket = CreateParentGameObject("BakedSpsSocket", socket.transform);
+                bakedSpsSocket.transform.localPosition = socket.position;
+                bakedSpsSocket.transform.localRotation = Quaternion.Euler(socket.rotation);
+
+                var bakeRoot = bakedSpsSocket.transform;
+                SocketProcessor.CreateSender(animator, bakeRoot, socket);
+                SocketProcessor.CreateLights(bakeRoot, socket.mode);
+                SocketProcessor.CreateHaptics(ctx, animator, bakeRoot, socket);
                 if (socket.enableDepthAnimations)
                 {
-                    SocketProcessor.CreateVRCContacts(ctx, socket.transform, socket);
+                    SocketProcessor.CreateVRCContacts(ctx, bakeRoot, socket);
                 }
-                SocketProcessor.CreateAutoDistance(ctx, socket);
+                SocketProcessor.CreateAutoDistance(ctx, bakeRoot, socket);
             }
             
             foreach (var plug in plugs)

--- a/ndmf_sps/Editor/Processor/Processor.cs
+++ b/ndmf_sps/Editor/Processor/Processor.cs
@@ -23,6 +23,7 @@ namespace com.meronmks.ndmfsps
         private static SPSforNDMFTagComponent[] components;
         private static Socket[] sockets;
         private static Plug[] plugs;
+        private static Dictionary<Socket, Transform> socketBakeRoots;
 
         internal static readonly string[] selfContacts =
         {
@@ -55,10 +56,12 @@ namespace com.meronmks.ndmfsps
         internal static void CreateComponent(BuildContext ctx)
         {
             var animator = ctx.AvatarRootObject.GetComponent<Animator>();
-            
+            socketBakeRoots = new Dictionary<Socket, Transform>();
+
             foreach (var socket in sockets)
             {
                 var bakedSpsSocket = CreateParentGameObject("BakedSpsSocket", socket.transform);
+                socketBakeRoots[socket] = bakedSpsSocket.transform;
                 bakedSpsSocket.transform.localPosition = socket.position;
                 bakedSpsSocket.transform.localRotation = Quaternion.Euler(socket.rotation);
 
@@ -185,8 +188,7 @@ namespace com.meronmks.ndmfsps
                     i++;
                 }
 
-                var bakedSpsSocket = socket.transform.Find("BakedSpsSocket");
-                SocketProcessor.CreateActiveAnimations(ctx, socket, socket.activeAnimationActions, bakedSpsSocket);
+                SocketProcessor.CreateActiveAnimations(ctx, socket, socket.activeAnimationActions, socketBakeRoots[socket]);
             }
             
             foreach (var plug in plugs)

--- a/ndmf_sps/Editor/Processor/Processor.cs
+++ b/ndmf_sps/Editor/Processor/Processor.cs
@@ -185,7 +185,8 @@ namespace com.meronmks.ndmfsps
                     i++;
                 }
 
-                SocketProcessor.CreateActiveAnimations(ctx, socket, socket.activeAnimationActions);
+                var bakedSpsSocket = socket.transform.Find("BakedSpsSocket");
+                SocketProcessor.CreateActiveAnimations(ctx, socket, socket.activeAnimationActions, bakedSpsSocket);
             }
             
             foreach (var plug in plugs)

--- a/ndmf_sps/Editor/Processor/SocketProcessor.cs
+++ b/ndmf_sps/Editor/Processor/SocketProcessor.cs
@@ -140,7 +140,7 @@ namespace com.meronmks.ndmfsps
                     handTouchZone.length,
                     Vector3.forward * -handTouchZone.length,
                     Processor.selfContacts,
-                    $"{SENDER_PARAMPREFIX}{root.gameObject.name.Replace("/", "_")}/{touchSelf.name.Replace("/", "_")}",
+                    $"{SENDER_PARAMPREFIX}{socket.gameObject.name.Replace("/", "_")}/{touchSelf.name.Replace("/", "_")}",
                     animator,
                     Processor.ReceiverParty.Self,
                     localOnly: true,
@@ -151,7 +151,7 @@ namespace com.meronmks.ndmfsps
                     handTouchZone.radius,
                     Vector3.forward * -(handTouchZone.length/2),
                     Processor.selfContacts,
-                    $"{SENDER_PARAMPREFIX}{root.gameObject.name.Replace("/", "_")}/{touchSelfClose.name.Replace("/", "_")}",
+                    $"{SENDER_PARAMPREFIX}{socket.gameObject.name.Replace("/", "_")}/{touchSelfClose.name.Replace("/", "_")}",
                     animator,
                     Processor.ReceiverParty.Self,
                     receiverType: ContactReceiver.ReceiverType.Constant,
@@ -165,7 +165,7 @@ namespace com.meronmks.ndmfsps
                     handTouchZone.length,
                     Vector3.forward * -handTouchZone.length,
                     Processor.bodyContacts,
-                    $"{SENDER_PARAMPREFIX}{root.gameObject.name.Replace("/", "_")}/{touchOthers.name.Replace("/", "_")}",
+                    $"{SENDER_PARAMPREFIX}{socket.gameObject.name.Replace("/", "_")}/{touchOthers.name.Replace("/", "_")}",
                     animator,
                     Processor.ReceiverParty.Others,
                     localOnly: true,
@@ -176,7 +176,7 @@ namespace com.meronmks.ndmfsps
                     handTouchZone.radius,
                     Vector3.forward * -(handTouchZone.length/2),
                     Processor.bodyContacts,
-                    $"{SENDER_PARAMPREFIX}{root.gameObject.name.Replace("/", "_")}/{touchOthersClose.name.Replace("/", "_")}",
+                    $"{SENDER_PARAMPREFIX}{socket.gameObject.name.Replace("/", "_")}/{touchOthersClose.name.Replace("/", "_")}",
                     animator,
                     Processor.ReceiverParty.Others,
                     receiverType: ContactReceiver.ReceiverType.Constant,
@@ -193,7 +193,7 @@ namespace com.meronmks.ndmfsps
                     {
                         "TPS_Pen_Penetrating"
                     },
-                    $"{SENDER_PARAMPREFIX}{root.gameObject.name.Replace("/", "_")}/{penOthers.name.Replace("/", "_")}",
+                    $"{SENDER_PARAMPREFIX}{socket.gameObject.name.Replace("/", "_")}/{penOthers.name.Replace("/", "_")}",
                     animator,
                     Processor.ReceiverParty.Others,
                     localOnly: true,
@@ -207,7 +207,7 @@ namespace com.meronmks.ndmfsps
                     {
                         "TPS_Pen_Penetrating"
                     },
-                    $"{SENDER_PARAMPREFIX}{root.gameObject.name.Replace("/", "_")}/{penOthersClose.name.Replace("/", "_")}",
+                    $"{SENDER_PARAMPREFIX}{socket.gameObject.name.Replace("/", "_")}/{penOthersClose.name.Replace("/", "_")}",
                     animator,
                     Processor.ReceiverParty.Others,
                     receiverType: ContactReceiver.ReceiverType.Constant,
@@ -224,7 +224,7 @@ namespace com.meronmks.ndmfsps
                     {
                         "TPS_Orf_Root"
                     },
-                    $"{SENDER_PARAMPREFIX}{root.gameObject.name.Replace("/", "_")}/{frotOthers.name.Replace("/", "_")}",
+                    $"{SENDER_PARAMPREFIX}{socket.gameObject.name.Replace("/", "_")}/{frotOthers.name.Replace("/", "_")}",
                     animator,
                     Processor.ReceiverParty.Others,
                     localOnly: true,
@@ -239,7 +239,7 @@ namespace com.meronmks.ndmfsps
                 {
                     "TPS_Pen_Root"
                 },
-                $"{SENDER_PARAMPREFIX}{root.gameObject.name.Replace("/", "_")}/{penSelfNewRoot.name.Replace("/", "_")}",
+                $"{SENDER_PARAMPREFIX}{socket.gameObject.name.Replace("/", "_")}/{penSelfNewRoot.name.Replace("/", "_")}",
                 animator,
                 Processor.ReceiverParty.Self,
                 localOnly: true,
@@ -253,7 +253,7 @@ namespace com.meronmks.ndmfsps
                 {
                     "TPS_Pen_Penetrating"
                 },
-                $"{SENDER_PARAMPREFIX}{root.gameObject.name.Replace("/", "_")}/{penSelfNewTip.name.Replace("/", "_")}",
+                $"{SENDER_PARAMPREFIX}{socket.gameObject.name.Replace("/", "_")}/{penSelfNewTip.name.Replace("/", "_")}",
                 animator,
                 Processor.ReceiverParty.Self,
                 localOnly: true,
@@ -267,7 +267,7 @@ namespace com.meronmks.ndmfsps
                 {
                     "TPS_Pen_Root"
                 },
-                $"{SENDER_PARAMPREFIX}{root.gameObject.name.Replace("/", "_")}/{penOthersNewRoot.name.Replace("/", "_")}",
+                $"{SENDER_PARAMPREFIX}{socket.gameObject.name.Replace("/", "_")}/{penOthersNewRoot.name.Replace("/", "_")}",
                 animator,
                 Processor.ReceiverParty.Others,
                 localOnly: true,
@@ -281,7 +281,7 @@ namespace com.meronmks.ndmfsps
                 {
                     "TPS_Pen_Penetrating"
                 },
-                $"{SENDER_PARAMPREFIX}{root.gameObject.name.Replace("/", "_")}/{penOthersNewTip.name.Replace("/", "_")}",
+                $"{SENDER_PARAMPREFIX}{socket.gameObject.name.Replace("/", "_")}/{penOthersNewTip.name.Replace("/", "_")}",
                 animator,
                 Processor.ReceiverParty.Others,
                 localOnly: true,
@@ -311,7 +311,7 @@ namespace com.meronmks.ndmfsps
                 var frontGameObject = Processor.CreateParentGameObject("Front", outerGameObject.transform);
                 var backGameObject = Processor.CreateParentGameObject("Back", outerGameObject.transform);
                 
-                var animParmPrefix = $"{root.gameObject.name.Replace("/", "_")}/Anim{(depthAction.enableSelf ? "" : "Others")}";
+                var animParmPrefix = $"{socket.gameObject.name.Replace("/", "_")}/Anim{(depthAction.enableSelf ? "" : "Others")}";
                 var outerRadius = Math.Max(0.01f, maxDist);
                 
                 Processor.CreateVRCContactReceiver(

--- a/ndmf_sps/Editor/Processor/SocketProcessor.cs
+++ b/ndmf_sps/Editor/Processor/SocketProcessor.cs
@@ -378,10 +378,10 @@ namespace com.meronmks.ndmfsps
         /// Plugが接近したら自動でOnになる機能に使われてるっぽい
         /// </summary>
         /// <param name="root"></param>
-        internal static void CreateAutoDistance(BuildContext ctx, Socket socket)
+        internal static void CreateAutoDistance(BuildContext ctx, Transform root, Socket socket)
         {
             var animator = ctx.AvatarRootObject.GetComponent<Animator>();
-            var autoDistanceRoot = Processor.CreateParentGameObject("AutoDistance", socket.transform);
+            var autoDistanceRoot = Processor.CreateParentGameObject("AutoDistance", root);
             var receiverGameObject = Processor.CreateParentGameObject("Receiver", autoDistanceRoot.transform);
             
             Processor.CreateVRCContactReceiver(
@@ -447,7 +447,7 @@ namespace com.meronmks.ndmfsps
             maMergeAnimator.matchAvatarWriteDefaults = true;
         }
 
-        internal static void CreateActiveAnimations(BuildContext ctx, Socket socket, List<IAction> actions)
+        internal static void CreateActiveAnimations(BuildContext ctx, Socket socket, List<IAction> actions, Transform bakedSpsSocket)
         {
             if (!socket.enableActiveAnimation)
             {
@@ -457,17 +457,17 @@ namespace com.meronmks.ndmfsps
             var maMergeAnimator = socket.gameObject.AddComponent<ModularAvatarMergeAnimator>();
             var controller = new AnimatorController();
             var parmName = $"{objectName}/Socket/Active"; //TODO: パラメータ名は一旦仮置き
-            
+
             controller.AddParameter(parmName, AnimatorControllerParameterType.Bool);
             controller.AddLayer($"SPS - Socket - Active Animation for {objectName}");
-            
+
             var layer = controller.layers[0];
             var stateMachine = layer.stateMachine;
 
             var offState = stateMachine.AddState("Off");
             var onState = stateMachine.AddState("On");
-            
-            foreach (Transform child in socket.transform)
+
+            foreach (Transform child in bakedSpsSocket)
             {
                 child.gameObject.SetActive(false);
                 if (child.gameObject.name.Equals("Senders") ||

--- a/ndmf_sps/Runtime/Socket.cs
+++ b/ndmf_sps/Runtime/Socket.cs
@@ -28,7 +28,10 @@ namespace com.meronmks.ndmfsps.runtime
         public Haptics haptics;
         
         public bool sendersOnly = false;
-        
+
+        public Vector3 position = Vector3.zero;
+        public Vector3 rotation = Vector3.zero;
+
         private void Reset()
         {
             detectLength = false;


### PR DESCRIPTION
## Summary

- Socket コンポーネントに `position`（Vector3）と `rotation`（Vector3, Euler角）フィールドを追加
- ビルド時に `BakedSpsSocket` 中間 GameObject を作成し、position/rotation を localPosition/localRotation として適用
- Senders, Lights, Haptics, Animations, AutoDistance の全子オブジェクトを BakedSpsSocket 配下に生成するよう変更
- Socket Inspector の「詳細設定」に position/rotation の UI を追加
- ローカライズキー追加（en-US / ja-JP）

### 背景: VRCFury との挙動差異

**症状**: VRCFury と比較して Socket の方向が異なってしまう場合がある。

**原因**: Socket の bakeRoot（中間オブジェクト）の有無。

VRCFury では `VRCFuryHapticSocketEditor.Bake()` が `BakedSpsSocket` という中間 GameObject を作成し、Socket の `position`/`rotation` プロパティから検出した `localPosition`/`localRotation` を適用する:

```
Socket (Transform)
 └─ BakedSpsSocket (localPosition + localRotation 適用) ← bakeRoot
     ├─ Senders/
     ├─ Lights/
     ├─ Haptics/
     └─ Animations/
```

ndmf_sps では Socket の `transform` を直接使用し、中間オブジェクトがなかった:

```
Socket (Transform) ← 直接ルート
 ├─ Senders/
 ├─ Lights/
 ├─ Haptics/
 └─ Animations/
```

**影響**:
- VRCFury の Socket は `addLight` プロパティ (Hole/Ring/Auto) に基づいてボーンの種類や DPS Light から回転を自動検出する（Head/Jaw→Hole 等）
- ndmf_sps の Socket は `transform` の向きがそのまま使われるため、Socket オブジェクトの Transform が想定と異なる向きの場合に方向がズレる
- VRCFury にある `socket.position`/`socket.rotation` による微調整機能が ndmf_sps には存在しなかった

### 変更後の階層構造

```
Socket (Transform)
 └─ BakedSpsSocket (localPosition + localRotation 適用)
     ├─ Senders/
     ├─ Lights/
     ├─ Haptics/
     ├─ Animations/
     └─ AutoDistance/
```

VRCFury の `BakedSpsSocket` と同等の構造になります。

## Test plan

- [ ] Socket コンポーネントの Inspector で「詳細設定」を開き、Position / Rotation フィールドが表示されることを確認
- [ ] Position / Rotation にゼロ以外の値を設定してビルドし、BakedSpsSocket の localPosition / localRotation に正しく反映されていることを確認
- [ ] Position / Rotation がデフォルト（ゼロ）のまま使った場合に、既存の動作と同等であることを確認
- [ ] Active Animation が正しく動作すること（BakedSpsSocket 配下の子オブジェクトが正しくトグルされること）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)