### PR TITLE
feat: Prefab 内アニメーションパスの自動解決

### DIFF
--- a/ndmf_sps/Editor/Processor/PlugProcessor.cs
+++ b/ndmf_sps/Editor/Processor/PlugProcessor.cs
@@ -806,8 +806,9 @@ namespace com.meronmks.ndmfsps
             maMergeAnimator.animator = controller;
             maMergeAnimator.layerType = VRCAvatarDescriptor.AnimLayerType.FX;
             maMergeAnimator.matchAvatarWriteDefaults = true;
+            maMergeAnimator.pathMode = MergeAnimatorPathMode.Absolute;
         }
-        
+
         internal static void CreateDepthAnims(BuildContext ctx, Plug plug, DepthAction depthAction, int count)
         {
             if (!plug.enableDepthAnimations || plug.depthActions.Count == 0) return;
@@ -855,6 +856,7 @@ namespace com.meronmks.ndmfsps
             maMergeAnimator.animator = controller;
             maMergeAnimator.layerType = VRCAvatarDescriptor.AnimLayerType.FX;
             maMergeAnimator.matchAvatarWriteDefaults = true;
+            maMergeAnimator.pathMode = MergeAnimatorPathMode.Absolute;
         }
 
         internal static Dictionary<string, float> GetScaleProps(IEnumerable<Material> materials)

--- a/ndmf_sps/Editor/Processor/Processor.cs
+++ b/ndmf_sps/Editor/Processor/Processor.cs
@@ -476,6 +476,64 @@ namespace com.meronmks.ndmfsps
             return Quaternion.identity;
         }
 
+        /// <summary>
+        /// VRCFury の CreateNearestMatchPathRewriter 相当。
+        /// animObject から rootObject に向かって親を遡りながら、
+        /// originalPath と結合して実在するオブジェクトへのパスを探す。
+        /// </summary>
+        internal static string ResolveNearestMatchPath(string originalPath, GameObject animObject, GameObject rootObject)
+        {
+            var current = animObject.transform;
+            var rootTransform = rootObject.transform;
+            while (current != null)
+            {
+                var prefix = AnimationUtility.CalculateTransformPath(current, rootTransform);
+                var testPath = string.IsNullOrEmpty(prefix)
+                    ? originalPath
+                    : string.IsNullOrEmpty(originalPath)
+                        ? prefix
+                        : $"{prefix}/{originalPath}";
+                if (rootTransform.Find(testPath) != null)
+                {
+                    return testPath;
+                }
+                if (current == rootTransform) break;
+                current = current.parent;
+            }
+            return originalPath;
+        }
+
+        /// <summary>
+        /// AnimationClip 内の全バインディングのパスを nearest-match で書き換える。
+        /// </summary>
+        internal static void RewriteClipPaths(AnimationClip clip, GameObject animObject, GameObject rootObject)
+        {
+            foreach (var binding in AnimationUtility.GetCurveBindings(clip))
+            {
+                var curve = AnimationUtility.GetEditorCurve(clip, binding);
+                var newPath = ResolveNearestMatchPath(binding.path, animObject, rootObject);
+                if (newPath != binding.path)
+                {
+                    AnimationUtility.SetEditorCurve(clip, binding, null);
+                    var newBinding = binding;
+                    newBinding.path = newPath;
+                    AnimationUtility.SetEditorCurve(clip, newBinding, curve);
+                }
+            }
+            foreach (var binding in AnimationUtility.GetObjectReferenceCurveBindings(clip))
+            {
+                var keys = AnimationUtility.GetObjectReferenceCurve(clip, binding);
+                var newPath = ResolveNearestMatchPath(binding.path, animObject, rootObject);
+                if (newPath != binding.path)
+                {
+                    AnimationUtility.SetObjectReferenceCurve(clip, binding, null);
+                    var newBinding = binding;
+                    newBinding.path = newPath;
+                    AnimationUtility.SetObjectReferenceCurve(clip, newBinding, keys);
+                }
+            }
+        }
+
         internal static (AnimationClip, AnimationClip) CreateAnimationClip(BuildContext ctx, GameObject clipRoot, List<IAction> actions, AnimatorState animatorState)
         {
             var onClip = new AnimationClip();
@@ -493,6 +551,7 @@ namespace com.meronmks.ndmfsps
             {
                 var copy = Object.Instantiate(firstClip);
                 copy.name = onClip.name;
+                RewriteClipPaths(copy, clipRoot, ctx.AvatarRootObject);
                 onClip = copy;
             }
             
@@ -504,8 +563,8 @@ namespace com.meronmks.ndmfsps
                     {
                         if (clipAction.clip == null || clipAction.clip == firstClip) break;
                         var copy = Object.Instantiate(clipAction.clip);
+                        RewriteClipPaths(copy, clipRoot, ctx.AvatarRootObject);
                         onClip = copy;
-                        
                         break;
                     }
                     case ObjectToggleAction objectToggleAction:
@@ -523,7 +582,7 @@ namespace com.meronmks.ndmfsps
                         
                         var curveBinding = new EditorCurveBinding();
                         
-                        curveBinding.path = AnimationUtility.CalculateTransformPath(objectToggleAction.obj.transform, clipRoot.transform);
+                        curveBinding.path = AnimationUtility.CalculateTransformPath(objectToggleAction.obj.transform, ctx.AvatarRootObject.transform);
                         curveBinding.type = typeof(GameObject);
                         curveBinding.propertyName = "m_IsActive";
 
@@ -549,7 +608,7 @@ namespace com.meronmks.ndmfsps
                             
                             var curveBinding = new EditorCurveBinding();
 
-                            curveBinding.path = ctx.AvatarRootObject.name;
+                            curveBinding.path = AnimationUtility.CalculateTransformPath(skin.transform, ctx.AvatarRootObject.transform);
                             curveBinding.type = typeof(SkinnedMeshRenderer);
                             curveBinding.propertyName = $"blendShape.{blendShape.blendShape}";
 

--- a/ndmf_sps/Editor/Processor/SocketProcessor.cs
+++ b/ndmf_sps/Editor/Processor/SocketProcessor.cs
@@ -445,6 +445,7 @@ namespace com.meronmks.ndmfsps
             maMergeAnimator.animator = controller;
             maMergeAnimator.layerType = VRCAvatarDescriptor.AnimLayerType.FX;
             maMergeAnimator.matchAvatarWriteDefaults = true;
+            maMergeAnimator.pathMode = MergeAnimatorPathMode.Absolute;
         }
 
         internal static void CreateActiveAnimations(BuildContext ctx, Socket socket, List<IAction> actions)
@@ -503,6 +504,7 @@ namespace com.meronmks.ndmfsps
             maMergeAnimator.animator = controller;
             maMergeAnimator.layerType = VRCAvatarDescriptor.AnimLayerType.FX;
             maMergeAnimator.matchAvatarWriteDefaults = true;
+            maMergeAnimator.pathMode = MergeAnimatorPathMode.Absolute;
         }
     }
 }


### PR DESCRIPTION
## Summary

- VRCFury 互換の nearest-match パスリライターを実装し、Prefab 内のアニメーションクリップのパスを自動解決
- ObjectToggleAction のパス計算をアバタールート基準に修正
- BlendShapeAction のパス計算を修正（`ctx.AvatarRootObject.name` → `CalculateTransformPath`）
- MergeAnimator の pathMode を Absolute に設定

### 背景: VRCFury との挙動差異

VRCFury はユーザーが設定したアニメーションクリップのパスを、Prefab 内の位置関係から自動的にアバタールート基準に変換する。ndmf_sps にはこの変換処理がなかった。

**具体例:**
```
Avatar
  Example           ← prefab ルート
    Socket           ← SPS Socket コンポーネント付き
    Obj
      View
```

SPS Socket に割り当てたアニメーションクリップに `"Obj/View"` というパスが記述されている場合:

- **VRCFury**: `CreateNearestMatchPathRewriter` が自動でパスを解決
  1. `Join("Example/Socket", "Obj/View")` = `"Example/Socket/Obj/View"` → 存在しない
  2. `Join("Example", "Obj/View")` = `"Example/Obj/View"` → **存在する** → 採用

- **ndmf_sps（修正前）**: パスの書き換え処理がなく、`"Obj/View"` はアバタールート直下を探してしまい見つからない

**ObjectToggleAction** にも同様の問題があった。`AnimationUtility.CalculateTransformPath(target, clipRoot)` で Socket/Plug 基準のパスを生成するため、対象が Socket/Plug の子孫でない場合（Prefab 内の兄弟オブジェクト等）にパスが壊れていた。VRCFury は `target.GetPath(avatarObject)` とアバタールート基準のパスを直接使う。

### 変更内容

| Action | 変更前 | 変更後 |
|--------|--------|--------|
| AnimationClipAction | パスそのまま使用 | nearest-match で書き換え（アバタールート基準） |
| ObjectToggleAction | `CalculateTransformPath(target, clipRoot)` | `CalculateTransformPath(target, avatarRoot)` |
| BlendShapeAction | `ctx.AvatarRootObject.name`（不正） | `CalculateTransformPath(skin, avatarRoot)` |
| MergeAnimator pathMode | デフォルト（未設定） | Absolute |

## Test plan

- [ ] Prefab 内に Socket を配置し、アニメーションクリップに Prefab 内の兄弟オブジェクトへのパスを設定 → ビルド後にアニメーションが正しく適用されることを確認
- [ ] ObjectToggleAction で Socket の子孫でないオブジェクト（Prefab 内の兄弟等）をトグル対象に設定 → 正しく動作することを確認
- [ ] BlendShapeAction で SkinnedMeshRenderer のブレンドシェイプを設定 → 正しいパスでアニメーションが生成されることを確認
- [ ] Socket/Plug の直下に作成されるオブジェクト（Senders, Lights 等）の Active Animation が引き続き正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)