### PR TITLE
fix: BakedSpsPlug を常にアクティブで生成する

### DIFF
--- a/ndmf_sps/Editor/Processor/Processor.cs
+++ b/ndmf_sps/Editor/Processor/Processor.cs
@@ -108,8 +108,8 @@ namespace com.meronmks.ndmfsps
                             material.name = sourceMaterial.name;
                             material.CopyPropertiesFromMaterial(sourceMaterial);
                             material.shader = newShader;
-                            material.SetFloat("_SPS_Enabled", plug.animatedToggle ? 1f : 0f);
-                            bakedSpsPlug.SetActive(plug.animatedToggle);
+                            material.SetFloat("_SPS_Enabled", 1f);
+                            bakedSpsPlug.SetActive(true);
                             material.SetFloat("_SPS_Length", size.worldLength);
                             material.SetFloat("_SPS_BakedLength", size.worldLength);
                             material.SetFloat("_SPS_Overrun", plug.allowHoleOverrun ? 1f : 0f);


### PR DESCRIPTION
## Summary

- `bakedSpsPlug.SetActive(plug.animatedToggle)` → `bakedSpsPlug.SetActive(true)` に変更
- `_SPS_Enabled` を常に `1f` に設定

### 背景: VRCFury との挙動差異

`plug.animatedToggle` がデフォルト値 `false` の場合:

**ndmf_sps（修正前）:**
- `_SPS_Enabled` = 0 → SPS シェーダー無効
- `bakedSpsPlug.SetActive(false)` → BakedSpsPlug とその全子（Senders, Haptics, SpsPlus）が非アクティブ
- 結果として Plug が機能しない

**VRCFury:**
- BakedSpsPlug は常にアクティブ
- `_SPS_Enabled` = 1f（常に有効）
- `animatedToggle`（VRCFury では `spsAnimatedEnabled`）はアニメーションでトグルできるようにするかの設定であり、初期状態で無効にする設定ではない

## Test plan

- [ ] `animatedToggle = false`（デフォルト）の Plug がビルド後に正しく動作することを確認
- [ ] BakedSpsPlug 配下の Senders/Haptics/SpsPlus がアクティブであることを確認
- [ ] `animatedToggle = true` の場合も引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)